### PR TITLE
tiny fix

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,3 +1,2 @@
-;; discount
-Gustavo Lopes [cataphract] <cataphract@php.net> (lead)
-Pierre-Alain Joye [pajoye] <pierre.php@gmail.com> (lead)
+discount
+Gustavo Lopes, Pierre-Alain Joye


### PR DESCRIPTION
Please consider fixing CREDITS so we can run automatic builds on Windows. Manually fixed the package builds fine, see http://windows.php.net/downloads/pecl/releases/discount/1.0.0/ ... The CREDITS file is used by windows builds to generate template files, so please no emails, special chars, etc. in there.

Also I might report the package name as an issue. Namely it's markdown on pecl, but discount when compiled. If that can't be fixed, that's fine.
